### PR TITLE
Update 2013-07-31-php-fait-nimporte-quoi-avec-les-closures.md

### DIFF
--- a/_posts/2013-07-31-php-fait-nimporte-quoi-avec-les-closures.md
+++ b/_posts/2013-07-31-php-fait-nimporte-quoi-avec-les-closures.md
@@ -119,3 +119,5 @@ Julien Pauli à la rescousse avec [un patch](http://pastebin.com/QSEWQb8U):
 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 Affaire à suivre !
+
+"Et mon cul c'est du teflon?"


### PR DESCRIPTION
Le rire est une activité buccale provoqué par le drolisme.
